### PR TITLE
Using constructor params with makeExternalStore.

### DIFF
--- a/src/stores/ExternalStoreAsync.test.ts
+++ b/src/stores/ExternalStoreAsync.test.ts
@@ -1,4 +1,4 @@
-import fetchMock from 'fetch-mock';
+import fetchMock from 'fetch-mock-jest';
 import { ExternalStoreAsync } from './ExternalStoreAsync'
 
 const BASE_URL = 'https://jsonplaceholder.typicode.com';
@@ -7,33 +7,53 @@ const BASE_URL = 'https://jsonplaceholder.typicode.com';
 type User = { id: number; name: string; username: string; email: string };
 type Todo = { id: number; title: string; completed: boolean; userId: number };
 
+const MOCK_USER = { id: 1, name: 'foo', username: 'foobar', email: 'foo@bar.com' };
+const MOCK_TODOS: Todo[] = [
+  { id: 1, userId: 1, title: 'Todo 1', completed: false },
+  { id: 2, userId: 1, title: 'Todo 2', completed: false },
+];
+
+const fetchUser = jest.fn((userId: number): Promise<User> =>
+  fetch(`${BASE_URL}/users/${userId}`)
+    .then(res => res.json()));
+
+const fetchUserTodos = jest.fn((userId: number): Promise<Todo[]> =>
+  fetch(`${BASE_URL}/users/${userId}/todos`)
+    .then(res => res.json()));
+
 class UserStore extends ExternalStoreAsync<User> {
   promise = fetchUser;
 }
 class UserTodosStore extends ExternalStoreAsync<Todo[]> {
   promise = fetchUserTodos;
 }
-
-const fetchUser = (userId: number): Promise<User> =>
-  fetch(`${BASE_URL}/users/${userId}`)
-    .then(res => res.json());
-
-const fetchUserTodos = (userId: number): Promise<Todo[]> =>
-  fetch(`${BASE_URL}/users/${userId}/todos`)
-    .then(res => res.json());
-
-fetchMock.getOnce('https://jsonplaceholder.typicode.com/users/1', { id: 1 });
-fetchMock.getOnce('https://jsonplaceholder.typicode.com/users/1/todos', []);
+    
 
 describe('ExternalStoreFetch', () => {
-  test('constructor', async () => {
+  test('constructor with memoized get', async () => {    
+    fetchMock.getOnce(BASE_URL + '/users/1', MOCK_USER);
+    fetchMock.get(BASE_URL + '/users/1/todos', MOCK_TODOS);
+    
     const userStore = new UserStore();
-    const userTodosStore = new UserTodosStore();
+    const userTodosStore = new UserTodosStore([]);
 
     const user = await userStore.get(1);
     expect(user).toMatchObject({ id: 1 });
 
     const userTodos = await userTodosStore.get(1);
-    expect(userTodos).toEqual([]);
+    expect(userTodos).toEqual(MOCK_TODOS);
+
+    // Ensure n 'get' calls are only 'truly' made once.
+    await userTodosStore.get(1);
+    await userTodosStore.get(1);
+    await userTodosStore.get(1);
+    await userTodosStore.get(1);
+    await userTodosStore.get(1);
+
+    expect(fetchUserTodos).toHaveBeenCalledTimes(1);
+
+    userTodosStore.reset(1);
+    await userTodosStore.get(1);
+    expect(fetchUserTodos).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/stores/ExternalStoreFetch.ts
+++ b/src/stores/ExternalStoreFetch.ts
@@ -1,42 +1,47 @@
-import { memoize } from '../utils/memoize';
-import { ExternalStore } from './ExternalStore';
+// WIP - API pending ExternalStoreAsync
+// import { memoize } from '../utils/memoize';
+// import { ExternalStore } from './ExternalStore';
 
-export class ExternalStoreFetch<T> extends ExternalStore<T> {
-  declare BASE_URL: string;
-  declare error?: Error;
+// export class ExternalStoreFetch<T> extends ExternalStore<T> {
+//   declare BASE_URL: string;
+//   declare error?: Error;
 
-  url(...params: any[]): string {
-    return '';
-  }
+//   url(...params: any[]): string {
+//     return `${params.join(':')}`;
+//   }
 
-  get fetch(): (...args: Parameters<typeof this['url']>) => Promise<T> {
-    return memoize(
-      (...args: Parameters<typeof this['url']>) =>
-        fetch(`${this.BASE_URL}${this.url(...args)}`)
-          .then((res) => res.json())
-          .then((t) => this.value = t)
-          .catch((e: any) => this.error = e)
-    );
-  }
-}
+//   get fetch(): (...args: Parameters<typeof this['url']>) => Promise<T> {
+//     return memoize(
+//       (...args: Parameters<typeof this['url']>) =>
+//         fetch(`${this.BASE_URL}${this.url(...args)}`)
+//           .then((res) => res.json())
+//           .then((t) => {
+//             this.set(t);
+//             return t;
+//           })
+//           .catch((e: any) => this.error = e),
+//       this.url,
+//     );
+//   }
+// }
 
-class TypicodeStore<T> extends ExternalStoreFetch<T> {
-  BASE_URL = 'https://jsonplaceholder.typicode.com';
-}
+// class TypicodeStore<T> extends ExternalStoreFetch<T> {
+//   BASE_URL = 'https://jsonplaceholder.typicode.com';
+// }
 
-type Todo = {};
-type User = {};
+// type Todo = {};
+// type User = {};
 
-class TodoStore extends TypicodeStore<Todo> {
-  url() { return '/todos' }
-}
+// class TodoStore extends TypicodeStore<Todo> {
+//   url = () => '/todos';
+// }
 
-class UserStore extends TypicodeStore<User> {
-  url(userId: number) { return `/users/${userId}` }
-}
+// class UserStore extends TypicodeStore<User> {
+//   url = (userId: number) => `/users/${userId}`;
+// }
 
-const todoStore = new TodoStore();
-todoStore.fetch();
+// const todoStore = new TodoStore();
+// todoStore.fetch();
 
-const userStore = new UserStore();
-userStore.fetch(1);
+// const userStore = new UserStore();
+// userStore.fetch(1);

--- a/src/stores/makeExternalStore.ts
+++ b/src/stores/makeExternalStore.ts
@@ -1,7 +1,8 @@
 import { useSyncExternalStore } from "react";
 import { ExternalStore } from "./ExternalStore";
+import { ExternalStoreAsync } from "./ExternalStoreAsync";
 
-type MakeExternalStore<T, S extends typeof ExternalStore<T>> = {
+type MakeExternalStore<S extends typeof ExternalStore<T>, T = unknown> = {
   store: InstanceType<S>;
   reset: () => void;
   useValue: () => InstanceType<S>['value'];
@@ -32,13 +33,13 @@ type MakeExternalStore<T, S extends typeof ExternalStore<T>> = {
  *   return <>{result.map(...)}</>
  * }
  */
-export function makeExternalStore<T extends unknown, S extends typeof ExternalStore<T>>(
+export function makeExternalStore<S extends typeof ExternalStore<T>, T>(
   Store: S,
-  initializer: T | undefined = undefined,
-): MakeExternalStore<T, S> {
-  const store = new Store(initializer);
+  ...params: ConstructorParameters<S>
+): MakeExternalStore<S, T> {
+  const store = new Store(...params);
   const reset = () => {
-    store.set.bind(store)(initializer);
+    store.set.bind(store)(...params);
   };
   const useValue = () => useSyncExternalStore(
     store.subscribe.bind(store),

--- a/src/utils/memoize.test.ts
+++ b/src/utils/memoize.test.ts
@@ -10,9 +10,17 @@ describe('memoize', () => {
     expect(method).toBeCalledTimes(1);
     expect(value).toEqual(1);
 
-    // Once to return the memoized value
+    // Call n times to receive the memoized value.
     value = await memoizedMethod(1);
-    expect(method).toBeCalledTimes(1);
-    expect(value).toEqual(1);
+    value = await memoizedMethod(1);
+    value = await memoizedMethod(1);
+
+    // Wrapped method only called once.
+    expect(method).toHaveBeenCalledTimes(1);
+
+    // Reset to receall method.
+    memoizedMethod.reset(1);
+    memoizedMethod(1);
+    expect(method).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/utils/memoize.ts
+++ b/src/utils/memoize.ts
@@ -1,26 +1,35 @@
 type MemoKey<T extends (...args: any[]) => any> = (...args: Parameters<T>) => string | string;
+export type Memoize<T extends (...args: any[]) => any> = ((...args: Parameters<T>) => ReturnType<T>) & {
+  reset: (...args: Parameters<T>) => void;
+}
 
 const defaultMemoKey = (...args: any[]): string => args.join(' ; ');
 
 /**
  * 
- * @param callback 
+ * @param method Method that returns a promise.
  * @param memoKey Any function
  * @returns 
  */
 export function memoize<
   T extends (...args: any[]) => any
 >(
-  callback: T,
+  method: T,
   memoKey: MemoKey<T> = defaultMemoKey,
-): (...args: Parameters<T>) => ReturnType<T> extends Promise<infer U> ? Promise<U> : Promise<ReturnType<T>> {
+) {
   const memos = new Map<string, ReturnType<T>>()
-  return (...args: Parameters<T>) => {
-    const key = memoKey(...args);
-    if (memos.has(key)) return memos.get(key);
-    return callback(...args).then((value: ReturnType<T>) => {
-      memos.set(key, value);
-      return value;
-    });
-  }
+  return Object.assign(
+    (...args: Parameters<T>) => {
+      const key = memoKey(...args);
+      if (memos.has(key)) return memos.get(key);
+      return method(...args).then((value: ReturnType<T>) => {
+        memos.set(key, value);
+        return value;
+      });
+    }, {
+    reset: (...args: Parameters<T>) => {
+      const key = memoKey(...args);
+      if (memos.has(key)) memos.delete(key);
+    }
+  });
 }


### PR DESCRIPTION
## Constructor params in makeExternalStore.
Now you can use constructor parameters with strong types with `makeExternalStore`

### `ExternalStore<T>`
```typescript
const loginStore = makeExternalStore(ExternalStore<LoginData>, { email: '', password: '' });
```

### `ExternalStoreAsync<T>`
```typescript
const fetchUser = (userId: number) => fetch(url + userId).then(res => res.json() as Promise<User>);
const userStore = makeExternalStore(ExternalStoreAsync<User>, undefined, fetchUser);
const user = await userStore.store.get(1);

// Call n times with arg 1 to make only one memoized promise call.
await userStore.store.get(1);
await userStore.store.get(1);
await userStore.store.get(1);

// Call `store.get.reset(userId)` to reset the cache for `store.get(userId)`
userStore.store.get.reset(1);
```